### PR TITLE
revert: Remove Bash helper function in favor of LHAPDF CLI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,9 +66,6 @@ RUN mkdir -p /code && \
     cmake --build . --target install && \
     rm -rf /code
 
-COPY download-lhapdf.sh /usr/local/bin/download-lhapdf
-RUN chmod +x /usr/local/bin/download-lhapdf
-
 # Enable tab completion by uncommenting it from /etc/bash.bashrc
 # The relevant lines are those below the phrase "enable bash completion in interactive shells"
 RUN export SED_RANGE="$(($(sed -n '\|enable bash completion in interactive shells|=' /etc/bash.bashrc)+1)),$(($(sed -n '\|enable bash completion in interactive shells|=' /etc/bash.bashrc)+7))" && \

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ Example:
 
 ```
 $ lhapdf get CT10nlo
+$ lhapdf show CT10nlo | grep ID
+LHAPDF ID: 11000
 $ find /usr/local/ -iname "CT10nlo.info"
 /usr/local/share/LHAPDF/CT10nlo/CT10nlo.info
 ```

--- a/README.md
+++ b/README.md
@@ -18,6 +18,47 @@ docker pull matthewfeickert/momemta-python:latest
 docker run --rm -it matthewfeickert/momemta-python:latest
 ```
 
+### LHAPDF PDF Sets
+
+No LHAPDF PDF sets are included in the Docker image by default.
+To download LHAPDF PDF sets for use, use the `lhapdf get` CLI
+
+```
+$ lhapdf --help
+usage: lhapdf [-h] [--listdir LISTDIR] [--pdfdir PDFDIR] [--source SOURCES] [--quiet] [--verbose] [--version] COMMAND [suboptions]
+
+A program for managing LHAPDF parton distribution function data files.
+
+The main sub-commands that can be used are:
+  - list|ls:     list available PDF sets, optionally filtered and/or categorised by status
+  - show:        show metadata details of specified PDF sets
+  - update:      download and install a new PDF set index file
+  - install|get: download and install new PDF set data files
+  - upgrade:     download and install newer replacement PDF set data files where available
+
+positional arguments:
+  COMMAND [suboptions]  Subcommand to run
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --listdir LISTDIR     Directory containing the lhapdf.index list file [default: /usr/local/share/LHAPDF]
+  --pdfdir PDFDIR       Directory for installation of PDF set data [default: /usr/local/share/LHAPDF]
+  --source SOURCES      Prepend a path or URL to be used as a source of data files [default: ['/cvmfs/sft.cern.ch/lcg/external/lhapdfsets/current/', 'http://lhapdfsets.web.cern.ch/lhapdfsets/current/']]
+  --quiet               Suppress normal messages
+  --verbose             Output debug messages
+  --version             show program's version number and exit
+```
+
+Example:
+
+```
+$ lhapdf get CT10nlo
+$ find /usr/local/ -iname "CT10nlo.info"
+/usr/local/share/LHAPDF/CT10nlo/CT10nlo.info
+```
+
+A [complete list of available LHAPDF PDF sets](https://lhapdf.hepforge.org/pdfsets.html) is available on the LHAPDF website.
+
 ## Tests
 
 To run the [MoMEMta `TTbar_FullyLeptonic` tutorial](https://github.com/MoMEMta/Tutorials/tree/v1.0.0) (compute weights under the hypothesis of top quark pair production with fully leptonic decay) either run

--- a/download-lhapdf.sh
+++ b/download-lhapdf.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-
-function download_LHAPDF() {
-  # 1: LHAPDF set name
-  local pdfset_name="${1}"
-  lhapdf --source http://lhapdfsets.web.cern.ch/lhapdfsets/current/ get "${pdfset_name}"
-}
-
-download_LHAPDF "$@" || exit 1

--- a/tests/tt_fullyleptonic_tutorial.sh
+++ b/tests/tt_fullyleptonic_tutorial.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-download-lhapdf CT10nlo
+lhapdf get CT10nlo
 
 # Clone and built tutorials
 git clone --depth 1 https://github.com/MoMEMta/Tutorials.git \


### PR DESCRIPTION
Instead of wrapping the LHAPDF CLI in a Bash wrapper, just use the existing CLI. It is a sufficient tool and it is better to advocate for learning the existing tools then contributing to wrapper-madness.

```
* Use the LHAPDF CLI over custom Bash wrapper
* Add instructions on how to use the LHAPDF CLI to the README
```