### PR TITLE
refactor: Use CMake v3 build syntax for greater readability

### DIFF
--- a/tests/tt_fullyleptonic_tutorial.sh
+++ b/tests/tt_fullyleptonic_tutorial.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+# Download required LHAPDF set
 lhapdf get CT10nlo
 
 # Clone and build tutorials

--- a/tests/tt_fullyleptonic_tutorial.sh
+++ b/tests/tt_fullyleptonic_tutorial.sh
@@ -2,27 +2,25 @@
 
 lhapdf get CT10nlo
 
-# Clone and built tutorials
+# Clone and build tutorials
 git clone --depth 1 https://github.com/MoMEMta/Tutorials.git \
   --branch v1.0.0 \
   --single-branch
-cd Tutorials
-mkdir build
-cd build
 cmake \
   -DCMAKE_CXX_STANDARD=17 \
-  ..
-cmake --build . -- -j$(($(nproc) - 1))
+  -S Tutorials \
+  -B Tutorials/build
+cmake Tutorials/build -L
+cmake --build Tutorials/build -- -j$(($(nproc) - 1))
 
-# Built Matrix Elements
-cd ../TTbar_FullyLeptonic/MatrixElement/
-mkdir build
-cd build
+# Build Matrix Elements
 cmake \
   -DCMAKE_CXX_STANDARD=17 \
-  ..
-cmake --build . -- -j$(($(nproc) - 1))
+  -S Tutorials/TTbar_FullyLeptonic/MatrixElement \
+  -B Tutorials/TTbar_FullyLeptonic/MatrixElement/build
+cmake Tutorials/TTbar_FullyLeptonic/MatrixElement/build -L
+cmake --build Tutorials/TTbar_FullyLeptonic/MatrixElement/build -- -j$(($(nproc) - 1))
 
 # Run ttbar fully leptonic example
-cd ../../../build/
+cd Tutorials/build
 TTbar_FullyLeptonic/TTbar_FullyLeptonic.exe


### PR DESCRIPTION
```
* Use CMake v3 build syntax to reduce directory manipulation and directory movement
   - Using -S and -B to specify source and build directory paths improves readability and avoids long chains of ../ for directory movement
* Add cmake <build dir> -L for spot checks of CMake build options and configurations
```