### PR TITLE
feat: Update MoMEMta version to v1.0.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,16 +6,16 @@ image:
 	docker build . \
 	-f docker/debian/Dockerfile \
 	--build-arg LHAPDF_VERSION=6.2.3 \
-	--build-arg MOMEMTA_VERSION=v1.0.0 \
+	--build-arg MOMEMTA_VERSION=v1.0.1 \
 	-t neubauergroup/momemta-python:latest \
-	-t neubauergroup/momemta-python:1.0.0
+	-t neubauergroup/momemta-python:1.0.1
 	--compress .
 
 debug:
 	docker build . \
 	-f docker/debian/Dockerfile \
 	--build-arg LHAPDF_VERSION=6.2.3 \
-	--build-arg MOMEMTA_VERSION=v1.0.0 \
+	--build-arg MOMEMTA_VERSION=v1.0.1 \
 	-t neubauergroup/momemta-python:debug-local
 
 test:

--- a/docker/centos/Dockerfile
+++ b/docker/centos/Dockerfile
@@ -58,7 +58,7 @@ RUN mkdir -p /code && \
 
 # MOMEMTA CXX_STANDARD must match ROOT's
 # Currently using C++14
-ARG MOMEMTA_VERSION=v1.0.0
+ARG MOMEMTA_VERSION=v1.0.1
 # hadolint ignore=SC1091
 RUN mkdir -p /code && \
     cd /code && \

--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -44,7 +44,7 @@ RUN mkdir -p /code && \
     rm -rf /code
 
 # Install MoMEMta
-ARG MOMEMTA_VERSION=v1.0.0
+ARG MOMEMTA_VERSION=v1.0.1
 RUN mkdir -p /code && \
     cd /code && \
     git clone --depth 1 https://github.com/MoMEMta/MoMEMta.git \


### PR DESCRIPTION
Following PR #7, update the MoMEMta version to `v1.0.1` following @swertz's fixes.

```
* Update MoMEMta release used to v1.0.1
   - c.f. https://github.com/MoMEMta/MoMEMta/releases/tag/v1.0.1
```