### PR TITLE
chore: Set CMake C++ standard used from ROOT

### DIFF
--- a/.github/workflows/docker-centos.yml
+++ b/.github/workflows/docker-centos.yml
@@ -109,7 +109,6 @@ jobs:
           -w $PWD
           neubauergroup/momemta-python-centos:sha-${GITHUB_SHA::8}
           'source scl_source enable devtoolset-8 && \
-           sed -i 's/CMAKE_CXX_STANDARD=17/CMAKE_CXX_STANDARD=14/g' tests/tt_fullyleptonic_tutorial.sh && \
            . tests/tt_fullyleptonic_tutorial.sh'
 
       - name: Build and publish to registry

--- a/tests/tt_fullyleptonic_tutorial.sh
+++ b/tests/tt_fullyleptonic_tutorial.sh
@@ -11,7 +11,7 @@ lhapdf get CT10nlo
 # Get CMAKE_CXX_STANDARD ROOT was built with
 ROOT_CONFIG_CXX=$(root-config --cflags | awk '{print $2}')
 ROOT_CXX_STANDARD="${ROOT_CONFIG_CXX: -2}"
-unset ROOT_CXX_STANDARD
+unset ROOT_CONFIG_CXX
 
 # Clone and build tutorials
 git clone --depth 1 https://github.com/MoMEMta/Tutorials.git \
@@ -36,4 +36,4 @@ cmake --build Tutorials/TTbar_FullyLeptonic/MatrixElement/build -- -j$(($(nproc)
 cd Tutorials/build
 TTbar_FullyLeptonic/TTbar_FullyLeptonic.exe
 
-unset CMAKE_CXX_STANDARD
+unset ROOT_CXX_STANDARD

--- a/tests/tt_fullyleptonic_tutorial.sh
+++ b/tests/tt_fullyleptonic_tutorial.sh
@@ -1,14 +1,24 @@
 #!/usr/bin/env bash
 
+# bash "scrict mode"
+set -e
+set -u
+set -o pipefail
+
 # Download required LHAPDF set
 lhapdf get CT10nlo
+
+# Get CMAKE_CXX_STANDARD ROOT was built with
+ROOT_CONFIG_CXX=$(root-config --cflags | awk '{print $2}')
+ROOT_CXX_STANDARD="${ROOT_CONFIG_CXX: -2}"
+unset ROOT_CXX_STANDARD
 
 # Clone and build tutorials
 git clone --depth 1 https://github.com/MoMEMta/Tutorials.git \
   --branch v1.0.0 \
   --single-branch
 cmake \
-  -DCMAKE_CXX_STANDARD=17 \
+  -DCMAKE_CXX_STANDARD="${ROOT_CXX_STANDARD}" \
   -S Tutorials \
   -B Tutorials/build
 cmake Tutorials/build -L
@@ -16,7 +26,7 @@ cmake --build Tutorials/build -- -j$(($(nproc) - 1))
 
 # Build Matrix Elements
 cmake \
-  -DCMAKE_CXX_STANDARD=17 \
+  -DCMAKE_CXX_STANDARD="${ROOT_CXX_STANDARD}" \
   -S Tutorials/TTbar_FullyLeptonic/MatrixElement \
   -B Tutorials/TTbar_FullyLeptonic/MatrixElement/build
 cmake Tutorials/TTbar_FullyLeptonic/MatrixElement/build -L
@@ -25,3 +35,5 @@ cmake --build Tutorials/TTbar_FullyLeptonic/MatrixElement/build -- -j$(($(nproc)
 # Run ttbar fully leptonic example
 cd Tutorials/build
 TTbar_FullyLeptonic/TTbar_FullyLeptonic.exe
+
+unset CMAKE_CXX_STANDARD


### PR DESCRIPTION
```
* Set the CMAKE_CXX_STANDARD used in all builds to be the same as that used to build the version of ROOT used
   - Remove use of sed to set CMAKE_CXX_STANDARD
* Run tests/tt_fullyleptonic_tutorial.sh in Bash "strict mode"
```