### PR TITLE
feat: Add MadGraph5, COPY ROOT, factor out BOOST and LHAPDF

### DIFF
--- a/.github/workflows/docker-centos.yml
+++ b/.github/workflows/docker-centos.yml
@@ -2,10 +2,10 @@ name: Docker Images CentOS
 
 on:
   push:
-    branches:
-    - main
-    tags:
-    - v*
+    # branches:
+    # - main
+    # tags:
+    # - v*
   pull_request:
     branches:
     - main
@@ -113,7 +113,7 @@ jobs:
 
       - name: Build and publish to registry
         # every PR will trigger a push event on main, so check the push event is actually coming from main
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'Neubauer-Group/momemta-python'
+        # if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'Neubauer-Group/momemta-python'
         id: docker_build_latest
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/docker-centos.yml
+++ b/.github/workflows/docker-centos.yml
@@ -2,10 +2,10 @@ name: Docker Images CentOS
 
 on:
   push:
-    # branches:
-    # - main
-    # tags:
-    # - v*
+    branches:
+    - main
+    tags:
+    - v*
   pull_request:
     branches:
     - main
@@ -112,7 +112,7 @@ jobs:
 
       - name: Build and publish to registry
         # every PR will trigger a push event on main, so check the push event is actually coming from main
-        # if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'Neubauer-Group/momemta-python'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'Neubauer-Group/momemta-python'
         id: docker_build_latest
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/docker-centos.yml
+++ b/.github/workflows/docker-centos.yml
@@ -108,8 +108,7 @@ jobs:
           -v $PWD:$PWD
           -w $PWD
           neubauergroup/momemta-python-centos:sha-${GITHUB_SHA::8}
-          'source scl_source enable devtoolset-8 && \
-           . tests/tt_fullyleptonic_tutorial.sh'
+          '. tests/tt_fullyleptonic_tutorial.sh'
 
       - name: Build and publish to registry
         # every PR will trigger a push event on main, so check the push event is actually coming from main

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,6 @@ debug:
 debug-centos:
 	docker build . \
 	-f docker/centos/Dockerfile \
-	--build-arg ROOT_IMAGE=neubauergroup/centos-root-base:6.24.00 \
 	--build-arg MOMEMTA_VERSION=v1.0.1 \
 	-t neubauergroup/momemta-python-centos:debug-local
 

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,13 @@ debug:
 	--build-arg MOMEMTA_VERSION=v1.0.1 \
 	-t neubauergroup/momemta-python:debug-local
 
+debug-centos:
+	docker build . \
+	-f docker/centos/Dockerfile \
+	--build-arg LHAPDF_VERSION=6.2.3 \
+	--build-arg MOMEMTA_VERSION=v1.0.1 \
+	-t neubauergroup/momemta-python-centos:debug-local
+
 test:
 	docker run \
 		--rm \

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ debug:
 debug-centos:
 	docker build . \
 	-f docker/centos/Dockerfile \
-	--build-arg LHAPDF_VERSION=6.2.3 \
+	--build-arg ROOT_IMAGE=neubauergroup/centos-root-base:6.24.00 \
 	--build-arg MOMEMTA_VERSION=v1.0.1 \
 	-t neubauergroup/momemta-python-centos:debug-local
 

--- a/docker/centos/Dockerfile
+++ b/docker/centos/Dockerfile
@@ -81,7 +81,7 @@ RUN mkdir -p /code && \
 
 RUN cd /usr/local/venv/MG5_aMC/PLUGIN/ && \
     git clone --depth 1 https://github.com/MoMEMta/MoMEMta-MaGMEE.git \
-    --banch v1.0.0 \
+    --branch v1.0.0 \
     --single-branch
 
 ENV HOME /home/docker

--- a/docker/centos/Dockerfile
+++ b/docker/centos/Dockerfile
@@ -79,21 +79,11 @@ RUN mkdir -p /code && \
     cmake --build build --target install && \
     rm -rf /code
 
-# # Create user "docker"
-# RUN useradd --shell /bin/bash -m docker && \
-#    cp /root/.bashrc /home/docker/ && \
-#    mkdir /home/docker/data && \
-#    chown -R --from=root docker /home/docker && \
-#    chown -R --from=root docker /usr && \
-#    chown -R --from=root docker /usr/local
-
-# ENV HOME /home/docker
-# WORKDIR ${HOME}/data
-# # hadolint ignore=SC2016,SC1091
-# RUN cp /root/.bash_profile ${HOME}/.bash_profile && \
-#     cp /root/.bashrc ${HOME}/.bashrc && \
-#     echo "" >> ${HOME}/.bashrc && \
-#     echo 'export PATH=${HOME}/.local/bin:$PATH' >> ${HOME}/.bashrc
+ENV HOME /home/docker
+WORKDIR ${HOME}/data
+RUN chown -R --from=root docker /usr/local/root-cern && \
+    chown -R --from=root docker /home/docker && \
+    chown -R --from=root docker /home/docker/.mg5
 
 ENV USER=docker
 USER docker

--- a/docker/centos/Dockerfile
+++ b/docker/centos/Dockerfile
@@ -53,24 +53,6 @@ RUN mkdir -p /code && \
     cd / && \
     rm -rf /code
 
-# Install LHAPDF
-ARG LHAPDF_VERSION=6.2.3
-# hadolint ignore=SC2155,SC1091
-RUN mkdir -p /code && \
-    cd /code && \
-    wget https://lhapdf.hepforge.org/downloads/?f=LHAPDF-${LHAPDF_VERSION}.tar.gz -O LHAPDF-${LHAPDF_VERSION}.tar.gz && \
-    tar xvfz LHAPDF-${LHAPDF_VERSION}.tar.gz && \
-    cd LHAPDF-${LHAPDF_VERSION} && \
-    source scl_source enable devtoolset-8 && \
-    ./configure --help && \
-    export CXX=$(command -v g++) && \
-    export PYTHON=$(command -v python3) && \
-    ./configure \
-      --prefix=/usr/local/venv && \
-    make -j$(($(nproc) - 1)) && \
-    make install && \
-    rm -rf /code
-
 # MOMEMTA CXX_STANDARD must match ROOT's
 # Currently using C++14
 ARG MOMEMTA_VERSION=v1.0.1

--- a/docker/centos/Dockerfile
+++ b/docker/centos/Dockerfile
@@ -1,8 +1,6 @@
 ARG BUILDER_IMAGE=scailfin/madgraph5-amc-nlo-centos:mg5_amc3.1.1
-FROM ${BUILDER_IMAGE} as builder
-
 FROM neubauergroup/centos-root-base:6.24.00 as root_cern_image
-FROM builder
+FROM ${BUILDER_IMAGE} as builder
 
 USER root
 WORKDIR /

--- a/docker/centos/Dockerfile
+++ b/docker/centos/Dockerfile
@@ -1,5 +1,7 @@
-ARG BUILDER_IMAGE=neubauergroup/centos-root-base:6.24.00
+ARG BUILDER_IMAGE=scailfin/madgraph5-amc-nlo-centos:mg5_amc3.1.1
 FROM ${BUILDER_IMAGE} as builder
+
+COPY --from=neubauergroup/centos-root-base:6.24.00 /usr/local/root-cern /usr/local/root-cern
 
 USER root
 WORKDIR /usr/local

--- a/docker/centos/Dockerfile
+++ b/docker/centos/Dockerfile
@@ -79,23 +79,23 @@ RUN mkdir -p /code && \
     cmake --build build --target install && \
     rm -rf /code
 
-# Create user "docker"
-RUN useradd --shell /bin/bash -m docker && \
-   cp /root/.bashrc /home/docker/ && \
-   mkdir /home/docker/data && \
-   chown -R --from=root docker /home/docker && \
-   chown -R --from=root docker /usr && \
-   chown -R --from=root docker /usr/local
+# # Create user "docker"
+# RUN useradd --shell /bin/bash -m docker && \
+#    cp /root/.bashrc /home/docker/ && \
+#    mkdir /home/docker/data && \
+#    chown -R --from=root docker /home/docker && \
+#    chown -R --from=root docker /usr && \
+#    chown -R --from=root docker /usr/local
 
-ENV HOME /home/docker
-WORKDIR ${HOME}/data
-# hadolint ignore=SC2016,SC1091
-RUN cp /root/.bash_profile ${HOME}/.bash_profile && \
-    cp /root/.bashrc ${HOME}/.bashrc && \
-    echo "" >> ${HOME}/.bashrc && \
-    echo 'export PATH=${HOME}/.local/bin:$PATH' >> ${HOME}/.bashrc
+# ENV HOME /home/docker
+# WORKDIR ${HOME}/data
+# # hadolint ignore=SC2016,SC1091
+# RUN cp /root/.bash_profile ${HOME}/.bash_profile && \
+#     cp /root/.bashrc ${HOME}/.bashrc && \
+#     echo "" >> ${HOME}/.bashrc && \
+#     echo 'export PATH=${HOME}/.local/bin:$PATH' >> ${HOME}/.bashrc
 
-ENV USER docker
+ENV USER=docker
 USER docker
 ENV PYTHONPATH=/usr/local/venv/lib:$PYTHONPATH
 ENV LD_LIBRARY_PATH=/usr/local/venv/lib:$LD_LIBRARY_PATH

--- a/docker/centos/Dockerfile
+++ b/docker/centos/Dockerfile
@@ -15,6 +15,7 @@ ENV LD_LIBRARY_PATH=/usr/local/root-cern/lib:$LD_LIBRARY_PATH
 ENV ROOTSYS=/usr/local/root-cern
 ENV PATH="${PATH}:${ROOTSYS}/bin"
 
+# hadolint ignore=SC2046
 RUN yum update -y && \
     yum install -y epel-release && \
     yum install -y $(cat /tmp/packages.txt) && \

--- a/docker/centos/Dockerfile
+++ b/docker/centos/Dockerfile
@@ -79,6 +79,11 @@ RUN mkdir -p /code && \
     cmake --build build --target install && \
     rm -rf /code
 
+RUN cd /usr/local/venv/MG5_aMC/PLUGIN/ && \
+    git clone --depth 1 https://github.com/MoMEMta/MoMEMta-MaGMEE.git \
+    --banch v1.0.0 \
+    --single-branch
+
 ENV HOME /home/docker
 WORKDIR ${HOME}/data
 RUN chown -R --from=root docker /usr/local/root-cern && \

--- a/docker/centos/Dockerfile
+++ b/docker/centos/Dockerfile
@@ -34,25 +34,6 @@ RUN yum update -y && \
     python -m pip --no-cache-dir install --requirement /tmp/requirements.txt && \
     python -m pip list
 
-# Install BOOST
-# c.f. https://www.boost.org/doc/libs/1_76_0/more/getting_started/unix-variants.html
-ARG BOOST_VERSION=1.76.0
-# hadolint ignore=SC2046
-RUN mkdir -p /code && \
-    cd /code && \
-    BOOST_VERSION_UNDERSCORE="${BOOST_VERSION//\./_}" && \
-    curl --silent --location --remote-name "https://boostorg.jfrog.io/artifactory/main/release/${BOOST_VERSION}/source/boost_${BOOST_VERSION_UNDERSCORE}.tar.gz" && \
-    tar -xzf "boost_${BOOST_VERSION_UNDERSCORE}.tar.gz" && \
-    cd "boost_${BOOST_VERSION_UNDERSCORE}" && \
-    source scl_source enable devtoolset-8 && \
-    ./bootstrap.sh --help && \
-    ./bootstrap.sh \
-      --prefix=/usr/local/venv \
-      --with-python=$(command -v python3) && \
-    ./b2 install -j$(($(nproc) - 1)) && \
-    cd / && \
-    rm -rf /code
-
 # MOMEMTA CXX_STANDARD must match ROOT's
 # Currently using C++14
 ARG MOMEMTA_VERSION=v1.0.1

--- a/docker/centos/Dockerfile
+++ b/docker/centos/Dockerfile
@@ -1,14 +1,24 @@
 ARG BUILDER_IMAGE=scailfin/madgraph5-amc-nlo-centos:mg5_amc3.1.1
 FROM ${BUILDER_IMAGE} as builder
 
-COPY --from=neubauergroup/centos-root-base:6.24.00 /usr/local/root-cern /usr/local/root-cern
-
 USER root
-WORKDIR /usr/local
+WORKDIR /
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
+# COPY ROOT out of neubauergroup/centos-root-base:6.24.00
+ARG ROOT_IMAGE=neubauergroup/centos-root-base:6.24.00
+COPY --from="${ROOT_IMAGE}" /usr/local/root-cern /usr/local/root-cern
+COPY --from="${ROOT_IMAGE}" /tmp/packages.txt /tmp/packages.txt
+COPY --from="${ROOT_IMAGE}" /tmp/requirements.txt /tmp/requirements.txt
+ENV PYTHONPATH=/usr/local/root-cern/lib:$PYTHONPATH
+ENV LD_LIBRARY_PATH=/usr/local/root-cern/lib:$LD_LIBRARY_PATH
+ENV ROOTSYS=/usr/local/root-cern
+ENV PATH="${PATH}:${ROOTSYS}/bin"
+
 RUN yum update -y && \
+    yum install -y epel-release && \
+    yum install -y $(cat /tmp/packages.txt) && \
     yum install -y \
       centos-release-scl \
       vim \
@@ -19,7 +29,10 @@ RUN yum update -y && \
       wget && \
     yum install -y devtoolset-8 && \
     yum clean all && \
-    yum autoremove -y
+    yum autoremove -y && \
+    python -m pip --no-cache-dir install --upgrade pip setuptools wheel && \
+    python -m pip --no-cache-dir install --requirement /tmp/requirements.txt && \
+    python -m pip list
 
 # Install BOOST
 # c.f. https://www.boost.org/doc/libs/1_76_0/more/getting_started/unix-variants.html

--- a/docker/centos/Dockerfile
+++ b/docker/centos/Dockerfile
@@ -88,7 +88,8 @@ ENV HOME /home/docker
 WORKDIR ${HOME}/data
 RUN chown -R --from=root docker /usr/local/root-cern && \
     chown -R --from=root docker /home/docker && \
-    chown -R --from=root docker /home/docker/.mg5
+    chown -R --from=root docker /home/docker/.mg5 && \
+    printf "\nsource scl_source enable devtoolset-8\n" >> $HOME/.bash_profile
 
 ENV USER=docker
 USER docker

--- a/docker/centos/Dockerfile
+++ b/docker/centos/Dockerfile
@@ -1,16 +1,17 @@
 ARG BUILDER_IMAGE=scailfin/madgraph5-amc-nlo-centos:mg5_amc3.1.1
 FROM ${BUILDER_IMAGE} as builder
 
+FROM neubauergroup/centos-root-base:6.24.00 as root_cern_image
+FROM builder
+
 USER root
 WORKDIR /
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-# COPY ROOT out of neubauergroup/centos-root-base:6.24.00
-ARG ROOT_IMAGE=neubauergroup/centos-root-base:6.24.00
-COPY --from="${ROOT_IMAGE}" /usr/local/root-cern /usr/local/root-cern
-COPY --from="${ROOT_IMAGE}" /tmp/packages.txt /tmp/packages.txt
-COPY --from="${ROOT_IMAGE}" /tmp/requirements.txt /tmp/requirements.txt
+COPY --from=root_cern_image /usr/local/root-cern /usr/local/root-cern
+COPY --from=root_cern_image /tmp/packages.txt /tmp/packages.txt
+COPY --from=root_cern_image /tmp/requirements.txt /tmp/requirements.txt
 ENV PYTHONPATH=/usr/local/root-cern/lib:$PYTHONPATH
 ENV LD_LIBRARY_PATH=/usr/local/root-cern/lib:$LD_LIBRARY_PATH
 ENV ROOTSYS=/usr/local/root-cern

--- a/docker/centos/Dockerfile
+++ b/docker/centos/Dockerfile
@@ -20,14 +20,12 @@ RUN yum update -y && \
     yum install -y epel-release && \
     yum install -y $(cat /tmp/packages.txt) && \
     yum install -y \
-      centos-release-scl \
       vim \
       zlib \
       zlib-devel \
       bzip2-devel \
       bash-completion \
       wget && \
-    yum install -y devtoolset-8 && \
     yum clean all && \
     yum autoremove -y && \
     python -m pip --no-cache-dir install --upgrade pip setuptools wheel && \
@@ -69,8 +67,7 @@ ENV HOME /home/docker
 WORKDIR ${HOME}/data
 RUN chown -R --from=root docker /usr/local/root-cern && \
     chown -R --from=root docker /home/docker && \
-    chown -R --from=root docker /home/docker/.mg5 && \
-    printf "\nsource scl_source enable devtoolset-8\n" >> $HOME/.bash_profile
+    chown -R --from=root docker /home/docker/.mg5
 
 ENV USER=docker
 USER docker


### PR DESCRIPTION
```
* Add MadGraph5 by building on top of the the scailfin/madgraph5-amc-nlo-centos:mg5_amc3.1.1 image as a base image
   - Remove install of LHAPDF and BOOST as they are already in the MadGraph5 image
* COPY all of ROOT from neubauergroup/centos-root-base:6.24.00
* Add the MadGraph5 Plugin MoMEMta - MadGraph Matrix Element Exporter (MoMEMta-MaGMEE)
   - c.f. https://github.com/MoMEMta/MoMEMta-MaGMEE.git
* Remove explicit call of `source scl_source enable devtoolset-8` as already in base images
   - c.f. https://github.com/Neubauer-Group/centos-python3/pull/18
```