### PR TITLE
fix: Add MoMEMta-MaGMEE plugin to PYTHONPATH

### DIFF
--- a/.github/workflows/docker-centos.yml
+++ b/.github/workflows/docker-centos.yml
@@ -2,10 +2,10 @@ name: Docker Images CentOS
 
 on:
   push:
-    # branches:
-    # - main
-    # tags:
-    # - v*
+    branches:
+    - main
+    tags:
+    - v*
   pull_request:
     branches:
     - main
@@ -121,7 +121,7 @@ jobs:
 
       - name: Build and publish to registry
         # every PR will trigger a push event on main, so check the push event is actually coming from main
-        # if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'Neubauer-Group/momemta-python'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'Neubauer-Group/momemta-python'
         id: docker_build_latest
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/docker-centos.yml
+++ b/.github/workflows/docker-centos.yml
@@ -101,10 +101,19 @@ jobs:
           neubauergroup/momemta-python-centos:sha-${GITHUB_SHA::8}
           'ldd --version'
 
+      - name: Run pytest tests
+        # Need to run not below PWD to have non-root write with GHA
+        run: >-
+          docker run --rm
+          -v $PWD:$PWD
+          -w $PWD
+          neubauergroup/momemta-python-centos:sha-${GITHUB_SHA::8}
+          'python -m pip install pytest && \
+           pytest tests'
+
       - name: Run test program
         run: >-
           docker run --rm
-          --user root
           -v $PWD:$PWD
           -w $PWD
           neubauergroup/momemta-python-centos:sha-${GITHUB_SHA::8}

--- a/.github/workflows/docker-centos.yml
+++ b/.github/workflows/docker-centos.yml
@@ -2,10 +2,10 @@ name: Docker Images CentOS
 
 on:
   push:
-    branches:
-    - main
-    tags:
-    - v*
+    # branches:
+    # - main
+    # tags:
+    # - v*
   pull_request:
     branches:
     - main
@@ -112,7 +112,7 @@ jobs:
 
       - name: Build and publish to registry
         # every PR will trigger a push event on main, so check the push event is actually coming from main
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'Neubauer-Group/momemta-python'
+        # if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'Neubauer-Group/momemta-python'
         id: docker_build_latest
         uses: docker/build-push-action@v2
         with:

--- a/docker/centos/Dockerfile
+++ b/docker/centos/Dockerfile
@@ -58,8 +58,8 @@ RUN mkdir -p /code && \
     cmake --build build --target install && \
     rm -rf /code && \
     cd $(python -c 'import madgraph; print(madgraph.MG5DIR)')/PLUGIN/ && \
-    git clone --depth 1 https://github.com/MoMEMta/MoMEMta-MaGMEE.git \
-      --branch v1.0.0 \
+    git clone --depth 1 https://github.com/matthewfeickert/MoMEMta-MaGMEE.git \
+      --branch feat/apply-pyupgrade \
       --single-branch
 
 ENV HOME /home/docker

--- a/docker/centos/Dockerfile
+++ b/docker/centos/Dockerfile
@@ -63,17 +63,17 @@ RUN mkdir -p /code && \
       --branch master \
       --single-branch
 
-ENV HOME /home/docker
-WORKDIR ${HOME}/data
 RUN chown -R --from=root docker /usr/local/root-cern && \
     chown -R --from=root docker /home/docker && \
     chown -R --from=root docker /home/docker/.mg5
 
-ENV USER=docker
-USER docker
 # Need to place MoMEMta-MaGMEE plugin on PYTHONPATH
 # LD_LIBRARY_PATH and PATH already set in BUILDER_IMAGE
 ENV PYTHONPATH="/usr/local/venv/MG5_aMC/PLUGIN/MoMEMta-MaGMEE:${PYTHONPATH}"
+
+# Default user is root to avoid uid write permission problems with volumes
+ENV HOME /root
+WORKDIR ${HOME}/data
 
 ENTRYPOINT ["/bin/bash", "-l", "-c"]
 CMD ["/bin/bash"]

--- a/docker/centos/Dockerfile
+++ b/docker/centos/Dockerfile
@@ -71,7 +71,7 @@ RUN chown -R --from=root docker /usr/local/root-cern && \
 ENV USER=docker
 USER docker
 # Need to place MoMEMta-MaGMEE plugin on PYTHONPATH
-ENV PYTHONPATH="$(python -c 'import madgraph; print(madgraph.MG5DIR)')/PLUGIN/MoMEMta-MaGMEE:${PYTHONPATH}"
+ENV PYTHONPATH=$(python -c 'import madgraph; print(madgraph.MG5DIR)')/PLUGIN/MoMEMta-MaGMEE:"${PYTHONPATH}"
 ENV LD_LIBRARY_PATH=/usr/local/venv/lib:$LD_LIBRARY_PATH
 ENV PATH ${HOME}/.local/bin:$PATH
 

--- a/docker/centos/Dockerfile
+++ b/docker/centos/Dockerfile
@@ -72,9 +72,8 @@ RUN chown -R --from=root docker /usr/local/root-cern && \
 ENV USER=docker
 USER docker
 # Need to place MoMEMta-MaGMEE plugin on PYTHONPATH
+# LD_LIBRARY_PATH and PATH already set in BUILDER_IMAGE
 ENV PYTHONPATH="/usr/local/venv/MG5_aMC/PLUGIN/MoMEMta-MaGMEE:${PYTHONPATH}"
-ENV LD_LIBRARY_PATH=/usr/local/venv/lib:$LD_LIBRARY_PATH
-ENV PATH ${HOME}/.local/bin:$PATH
 
 ENTRYPOINT ["/bin/bash", "-l", "-c"]
 CMD ["/bin/bash"]

--- a/docker/centos/Dockerfile
+++ b/docker/centos/Dockerfile
@@ -71,7 +71,8 @@ RUN chown -R --from=root docker /usr/local/root-cern && \
 
 ENV USER=docker
 USER docker
-ENV PYTHONPATH=/usr/local/venv/lib:$PYTHONPATH
+# Need to place MoMEMta-MaGMEE plugin on PYTHONPATH
+ENV PYTHONPATH="$(python -c 'import madgraph; print(madgraph.MG5DIR)')/PLUGIN/MoMEMta-MaGMEE:${PYTHONPATH}"
 ENV LD_LIBRARY_PATH=/usr/local/venv/lib:$LD_LIBRARY_PATH
 ENV PATH ${HOME}/.local/bin:$PATH
 

--- a/docker/centos/Dockerfile
+++ b/docker/centos/Dockerfile
@@ -71,7 +71,7 @@ RUN chown -R --from=root docker /usr/local/root-cern && \
 ENV USER=docker
 USER docker
 # Need to place MoMEMta-MaGMEE plugin on PYTHONPATH
-ENV PYTHONPATH=$(python -c 'import madgraph; print(madgraph.MG5DIR)')/PLUGIN/MoMEMta-MaGMEE:"${PYTHONPATH}"
+ENV PYTHONPATH="/usr/local/venv/MG5_aMC/PLUGIN/MoMEMta-MaGMEE:${PYTHONPATH}"
 ENV LD_LIBRARY_PATH=/usr/local/venv/lib:$LD_LIBRARY_PATH
 ENV PATH ${HOME}/.local/bin:$PATH
 

--- a/docker/centos/Dockerfile
+++ b/docker/centos/Dockerfile
@@ -51,7 +51,7 @@ RUN mkdir -p /code && \
       -DCMAKE_CXX_STANDARD="${ROOT_CXX_STANDARD}" \
       -DPYTHON_BINDINGS=ON \
       -DPYTHON_MIN_VERSION=3 \
-      -DBoost_PYTHON_VERSION_TAG=3 \
+      -DBoost_PYTHON_VERSION_TAG=$(find /usr/local/venv/ -iname 'libboost_python*.so' | sed --regexp-extended 's/.*_python([0-9]+).*/\1/g') \
       -S MoMEMta \
       -B build && \
     cmake build -L && \

--- a/docker/centos/Dockerfile
+++ b/docker/centos/Dockerfile
@@ -56,12 +56,11 @@ RUN mkdir -p /code && \
     cmake build -L && \
     cmake --build build -- -j$(($(nproc) - 1)) && \
     cmake --build build --target install && \
-    rm -rf /code
-
-RUN cd /usr/local/venv/MG5_aMC/PLUGIN/ && \
+    rm -rf /code && \
+    cd $(python -c 'import madgraph; print(madgraph.MG5DIR)')/PLUGIN/ && \
     git clone --depth 1 https://github.com/MoMEMta/MoMEMta-MaGMEE.git \
-    --branch v1.0.0 \
-    --single-branch
+      --branch v1.0.0 \
+      --single-branch
 
 ENV HOME /home/docker
 WORKDIR ${HOME}/data

--- a/docker/centos/Dockerfile
+++ b/docker/centos/Dockerfile
@@ -59,8 +59,8 @@ RUN mkdir -p /code && \
     cmake --build build --target install && \
     rm -rf /code && \
     cd $(python -c 'import madgraph; print(madgraph.MG5DIR)')/PLUGIN/ && \
-    git clone --depth 1 https://github.com/matthewfeickert/MoMEMta-MaGMEE.git \
-      --branch feat/apply-pyupgrade \
+    git clone --depth 1 https://github.com/MoMEMta/MoMEMta-MaGMEE.git \
+      --branch master \
       --single-branch
 
 ENV HOME /home/docker

--- a/docker/centos/Dockerfile
+++ b/docker/centos/Dockerfile
@@ -36,6 +36,7 @@ RUN yum update -y && \
 # Currently using C++14
 ARG MOMEMTA_VERSION=v1.0.1
 # hadolint ignore=SC1091
+# hadolint ignore=SC2046
 RUN mkdir -p /code && \
     cd /code && \
     git clone --depth 1 https://github.com/MoMEMta/MoMEMta.git \

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -22,6 +22,12 @@ def test_import_fastjet():
     assert fastjet
 
 
+def test_import_momemta():
+    import momemta
+
+    assert momemta
+
+
 def test_import_ROOT():
     import ROOT
 

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,0 +1,28 @@
+def test_import_madgraph():
+    import madgraph
+
+    assert madgraph
+
+
+def test_import_lhapdf():
+    import lhapdf
+
+    assert lhapdf
+
+
+def test_import_pythia():
+    import pythia8
+
+    assert pythia8
+
+
+def test_import_fastjet():
+    import fastjet
+
+    assert fastjet
+
+
+def test_import_ROOT():
+    import ROOT
+
+    assert ROOT


### PR DESCRIPTION
Add [MoMEMta-MaGMEE MadGraph5 plugin](https://github.com/MoMEMta/MoMEMta-MaGMEE) to `PYTHONPATH` and build from its `master` branch to pickup https://github.com/MoMEMta/MoMEMta-MaGMEE/pull/10.

```
* Add MoMEMta-MaGMEE MadGraph5 plugin to PYTHONPATH
   - Build from `master` branch to pickup https://github.com/MoMEMta/MoMEMta-MaGMEE/pull/10
* Determine Boost_PYTHON_VERSION_TAG number (in this PR `38`) dynamically to properly build Python bindings
* Add dependencies Python import pytest tests
```